### PR TITLE
Feat/dr24 post processing script updates

### DIFF
--- a/RScripts/DR_22_Update_DM_pipeline.R
+++ b/RScripts/DR_22_Update_DM_pipeline.R
@@ -394,7 +394,8 @@ violin_score_associated <- ggplot(matches_tidy, aes(x = 0, y = score)) +
     geom = "pointrange", color = "black"
   ) +
   geom_hline(
-    aes(yintercept = 40, linetype = "Score threshold (40)"),
+    data = data.frame(yintercept = 40),
+    aes(yintercept = yintercept, , linetype = "Score threshold (40)"),
     color = "purple", linewidth = 0.8
   ) +
   scale_shape_manual(values = c("Mean ± SD" = 16)) +
@@ -696,7 +697,8 @@ violin_score_predicted <- ggplot(model_no0_nodisease_dist, aes(x = 0, y = score)
     geom = "pointrange", color = "black"
   ) +
   geom_hline(
-    aes(yintercept = 40, linetype = "Score threshold (40)"),
+    data = data.frame(yintercept = 40),
+    aes(yintercept = yintercept, , linetype = "Score threshold (40)"),
     color = "purple", linewidth = 0.8
   )  +
   scale_shape_manual(values = c("Mean ± SD" = 16)) +

--- a/RScripts/DR_22_Update_DM_pipeline.R
+++ b/RScripts/DR_22_Update_DM_pipeline.R
@@ -384,9 +384,43 @@ box <- base +
 density <- base +
   geom_density(fill = "lightblue", adjust = 1/4)
 
+
+violin_score_associated <- ggplot(matches_tidy, aes(x = 0, y = score)) +
+  geom_violin(fill = "#00AFBB", trim = FALSE, width = 0.3, adjust = 0.3) +
+  geom_boxplot(width = 0.02, fill = "white", outlier.shape = NA) +
+  stat_summary(
+    aes(shape = "Mean ± SD"),
+    fun.data = "mean_sdl", fun.args = list(mult = 1),
+    geom = "pointrange", color = "black"
+  ) +
+  geom_hline(
+    aes(yintercept = 40, linetype = "Score threshold (40)"),
+    color = "purple", linewidth = 0.8
+  ) +
+  scale_shape_manual(values = c("Mean ± SD" = 16)) +
+  scale_linetype_manual(values = c("Score threshold (40)" = "dashed")) +
+  guides(
+    shape = guide_legend(title = NULL),
+    linetype = guide_legend(title = NULL, override.aes = list(color = "purple"))
+  ) +
+  scale_x_continuous(expand = expansion(mult = c(0, 0.05))) +
+  theme_minimal() +
+  theme(
+    axis.text.x = element_blank(),
+    axis.ticks.x = element_blank(),
+    plot.margin = margin(t = 10, r = 10, b = 10, l = 0),
+    legend.position = c(0.9, 0.9)
+  ) +
+  labs(
+    x = "PhenoDigm match hits",
+    y = "PhenoDigm Score"
+  )
+
+
 histogram
 box
 density
+violin_score_associated
 
 # Disease gene(associated) summary stats:
 summary_stats_associated <- matches_tidy %>%
@@ -667,30 +701,36 @@ log_event(score_disease_predicted_max = summary_stats_predicted$max)
 log_event(score_disease_predicted_iqr = summary_stats_predicted$iqr)
 
 # Violin plot for visualisation and cutoff
-violin <- ggplot(model_no0_nodisease_dist, aes(x = 0, y = score)) +
-  geom_violin(fill = "#00AFBB", trim = FALSE, width=0.3) +
+violin_score_predicted <- ggplot(model_no0_nodisease_dist, aes(x = 0, y = score)) +
+  geom_violin(fill = "#00AFBB", trim = FALSE, width=0.3, adjust = 0.3) +
   geom_boxplot(width = 0.02, fill = "white", outlier.shape = NA) +
   stat_summary(
+    aes(shape = "Mean ± SD"),
     fun.data = "mean_sdl", fun.args = list(mult = 1),
     geom = "pointrange", color = "black"
   ) +
-  geom_hline(yintercept = 40, color = "purple", linetype = "dashed", linewidth = 0.8) +
+  geom_hline(
+    aes(yintercept = 40, linetype = "Score threshold (40)"),
+    color = "purple", linewidth = 0.8
+  )  +
+  scale_shape_manual(values = c("Mean ± SD" = 16)) +
+  scale_linetype_manual(values = c("Score threshold (40)" = "dashed")) +
+  guides(
+    shape = guide_legend(title = NULL),
+    linetype = guide_legend(title = NULL, override.aes = list(color = "purple"))
+  ) +
   scale_x_continuous(expand = expansion(mult = c(0, 0.05))) +
   theme_minimal() +
   theme(
     axis.text.x = element_blank(),
     axis.ticks.x = element_blank(),
     plot.margin = margin(t = 10, r = 10, b = 10, l = 0),
-    legend.position = "none"
+    legend.position = c(0.9,0.9)
   ) +
-  labs(y = "Score") +
+  labs(y = "PhenoDigm Score") +
   labs(x = "PhenoDigm other hits")
 
-violin
-
-write.table(model_no0_nodisease,
-            "./data/output/phenodigm_other_dr23.txt",
-            quote = F, sep = "\t", row.names = F)
+violin_score_predicted
 
 write_parquet(model_no0_nodisease,
               "./data/output/phenodigm_other_dr23.parquet")

--- a/RScripts/DR_22_Update_DM_pipeline.R
+++ b/RScripts/DR_22_Update_DM_pipeline.R
@@ -448,11 +448,11 @@ log_event(score_disease_associated_iqr = summary_stats_associated$iqr)
 
 write_parquet(phenodigm_matches_impc,
               "./data/output/phenodigm_matches_full.parquet",
-              compression="zstd", compression_level=12)
+              compression="zstd", compression_level=5)
 
 write_parquet(matches_tidy,
               "./data/output/phenodigm_matches.parquet",
-              compression="zstd", compression_level=12)
+              compression="zstd", compression_level=5)
 
 # gene summary file -------------------------------------------------------
 
@@ -485,7 +485,7 @@ filter_matches <- gene_summary_df %>%
 
 write_parquet(gene_summary_df,
               "./data/output/gene_summary.parquet",
-              compression="zstd", compression_level=12)
+              compression="zstd", compression_level=5)
 
 write.fst(gene_summary_df, "./data/output/gene_summary.fst")
 
@@ -721,7 +721,7 @@ violin_score_predicted <- ggplot(model_no0_nodisease_dist, aes(x = 0, y = score)
 violin_score_predicted
 
 write_parquet(model_no0_nodisease,
-              "./data/output/phenodigm_other.parquet")
+              "./data/output/phenodigm_other.parquet", compression="zstd", compression_level=5)
 
 # PhenoDigm other is getting quite large, we can split in multiple files of 35MB to comply with GitHub enterprise's limits.
 # 1. Calculate the the number of rows per chunk needed to fit the required file size.
@@ -999,9 +999,9 @@ top_genes_impc_models_tidy <- top_genes_impc_models %>%
 # Write all models file
 write_parquet(top_genes_all_models_tidy,
               "./data/output/phenodigm_scores_benchmarking_all_models.parquet",
-              compression="zstd", compression_level=12)
+              compression="zstd", compression_level=5)
 
 # Write impc models only file
 write_parquet(top_genes_impc_models_tidy,
               "./data/output/phenodigm_scores_benchmarking_impc_models.parquet",
-              compression="zstd", compression_level=12)
+              compression="zstd", compression_level=5)

--- a/RScripts/DR_22_Update_DM_pipeline.R
+++ b/RScripts/DR_22_Update_DM_pipeline.R
@@ -395,7 +395,7 @@ violin_score_associated <- ggplot(matches_tidy, aes(x = 0, y = score)) +
   ) +
   geom_hline(
     data = data.frame(yintercept = 40),
-    aes(yintercept = yintercept, , linetype = "Score threshold (40)"),
+    aes(yintercept = yintercept, linetype = "Score threshold (40)"),
     color = "purple", linewidth = 0.8
   ) +
   scale_shape_manual(values = c("Mean ± SD" = 16)) +
@@ -698,7 +698,7 @@ violin_score_predicted <- ggplot(model_no0_nodisease_dist, aes(x = 0, y = score)
   ) +
   geom_hline(
     data = data.frame(yintercept = 40),
-    aes(yintercept = yintercept, , linetype = "Score threshold (40)"),
+    aes(yintercept = yintercept, linetype = "Score threshold (40)"),
     color = "purple", linewidth = 0.8
   )  +
   scale_shape_manual(values = c("Mean ± SD" = 16)) +
@@ -725,7 +725,7 @@ write_parquet(model_no0_nodisease,
 
 # PhenoDigm other is getting quite large, we can split in multiple files under 50MB to comply with GitHub enterprise's limits.
 # 1. Calculate the number of rows per chunk needed to fit the required file size.
-# Setting in_memory_db to 90, resulted in <50MB per saved file
+# Setting in_memory_mb to 90, resulted in <50MB per saved file
 
 in_memory_mb      <- 90
 file_size_mb   <- as.numeric(object.size(model_no0_nodisease)) / (1024^2)

--- a/RScripts/DR_22_Update_DM_pipeline.R
+++ b/RScripts/DR_22_Update_DM_pipeline.R
@@ -723,13 +723,15 @@ violin_score_predicted
 write_parquet(model_no0_nodisease,
               "./data/output/phenodigm_other.parquet", compression="zstd", compression_level=5)
 
-# PhenoDigm other is getting quite large, we can split in multiple files of 35MB to comply with GitHub enterprise's limits.
-# 1. Calculate the the number of rows per chunk needed to fit the required file size.
-target_mb      <- 90
+# PhenoDigm other is getting quite large, we can split in multiple files under 50MB to comply with GitHub enterprise's limits.
+# 1. Calculate the number of rows per chunk needed to fit the required file size.
+# Setting in_memory_db to 90, resulted in <50MB per saved file
+
+in_memory_mb      <- 90
 file_size_mb   <- as.numeric(object.size(model_no0_nodisease)) / (1024^2)
 total_rows     <- nrow(model_no0_nodisease)
 rows_per_mb    <- total_rows / file_size_mb
-rows_per_chunk <- floor(rows_per_mb * target_mb)
+rows_per_chunk <- floor(rows_per_mb * in_memory_mb)
 
 # 2. Write to a new dir, in parquet format. Overwrites if existing. 
 write_dataset(

--- a/RScripts/DR_22_Update_DM_pipeline.R
+++ b/RScripts/DR_22_Update_DM_pipeline.R
@@ -1,6 +1,6 @@
-### IMPC DR21 models and PhenoDigm scores
+### IMPC post processing - models and PhenoDigm scores
 ### It requires:
-### 1) tables from PhenoDigm 22 sqlite database in Apocrita
+### 1) tables from PhenoDigm sqlite database in Apocrita
 ### 2) different IMPC files from the ftp repository
 ### 3) Auxiliary files and scripts: orthologue mapping and symbol checker
 ### https://www.gentar.org/orthology-api/api/ortholog/one_to_one/impc/write_to_tsv_file
@@ -445,21 +445,12 @@ log_event(score_disease_associated_iqr = summary_stats_associated$iqr)
 
 # export files for shiny app ----------------------------------------------
 
-
-write.table(phenodigm_matches_impc,
-            "./data/output/phenodigm_matches_DR23.txt",
-            quote = F, sep = "\t", row.names = F)
-
 write_parquet(phenodigm_matches_impc,
-              "./data/output/phenodigm_matches_DR23.parquet",
+              "./data/output/phenodigm_matches_full.parquet",
               compression="zstd", compression_level=12)
 
-write.table(matches_tidy,
-            "./data/output/phenodigm_matches_tidy_DR23.txt",
-            quote = F, sep = "\t", row.names = F)
-
 write_parquet(matches_tidy,
-              "./data/output/phenodigm_matches_tidy_DR23.parquet",
+              "./data/output/phenodigm_matches.parquet",
               compression="zstd", compression_level=12)
 
 # gene summary file -------------------------------------------------------
@@ -491,16 +482,11 @@ filter_matches <- gene_summary_df %>%
 
 # export gene summary file ------------------------------------------------
 
-
-# write.table(gene_summary_df ,
-#             "./data/output/gene_summary_DR23.txt",
-#             quote = F, sep = "\t", row.names = F)
-
 write_parquet(gene_summary_df,
-              "./data/output/gene_summary_DR23.parquet",
+              "./data/output/gene_summary.parquet",
               compression="zstd", compression_level=12)
 
-write.fst(gene_summary_df, "./data/output/gene_summary_DR23.fst")
+write.fst(gene_summary_df, "./data/output/gene_summary.fst")
 
 
 # home page gene summary --------------------------------------------------
@@ -560,7 +546,7 @@ gene_info <- gene_summary_df%>%
 
 # export home page gene summary --------------------------------------------------
 
-write_parquet(gene_info_with_phenotypes_reframe, "./data/output/home_gene_summary_dr23.parquet")
+write_parquet(gene_info_with_phenotypes_reframe, "./data/output/home_gene_summary.parquet")
 
 # match vs no match -------------------------------------------------------
 # Genes with PhenoDigm score
@@ -733,7 +719,25 @@ violin_score_predicted <- ggplot(model_no0_nodisease_dist, aes(x = 0, y = score)
 violin_score_predicted
 
 write_parquet(model_no0_nodisease,
-              "./data/output/phenodigm_other_dr23.parquet")
+              "./data/output/phenodigm_other.parquet")
+
+# PhenoDigm other is getting quite large, we can split in multiple files of 35MB to comply with GitHub enterprise's limits.
+# 1. Calculate the the number of rows per chunk needed to fit the required file size.
+target_mb      <- 90
+file_size_mb   <- as.numeric(object.size(model_no0_nodisease)) / (1024^2)
+total_rows     <- nrow(model_no0_nodisease)
+rows_per_mb    <- total_rows / file_size_mb
+rows_per_chunk <- floor(rows_per_mb * target_mb)
+
+# 2. Write to a new dir, in parquet format. Overwrites if existing. 
+write_dataset(
+  dataset = model_no0_nodisease,
+  path = "./data/output/phenodigm_other",
+  format = "parquet",
+  max_rows_per_file = rows_per_chunk,
+  existing_data_behavior = "overwrite",
+  basename_template = "part-{i}-phenodigm_other.parquet"
+)
 
 ###########################################################################
 #### impc vs non impc match
@@ -905,8 +909,6 @@ stats_df <- lapply(seq_along(json_lines), function(i) {
 
 write_parquet(stats_df,"./data/output/log/post_processing_results.parquet")
 
-df <-read_parquet("./data/output/log/post_processing_results.parquet")
-
 ##########################  Pheval-impc Benchmarking ####################################################
 # Finding all OMIM genes with an IMPC gene
 # Filtered version of stats_all file 
@@ -991,20 +993,13 @@ top_genes_impc_models_tidy <- top_genes_impc_models %>%
 #########################################################################################################
 
 # Write benchmarking files to be read by pheval_impc_phenodigm
-# Write all models file
-write.table(top_genes_all_models_tidy,
-            "./data/output/phenodigm_scores_benchmarking_DR23_all_models.txt",
-            quote = FALSE, sep = "\t", row.names = FALSE)
 
+# Write all models file
 write_parquet(top_genes_all_models_tidy,
-              "./data/output/phenodigm_scores_benchmarking_DR23_all_models.parquet",
+              "./data/output/phenodigm_scores_benchmarking_all_models.parquet",
               compression="zstd", compression_level=12)
 
 # Write impc models only file
-write.table(top_genes_impc_models_tidy,
-            "./data/output/phenodigm_scores_benchmarking_DR23_impc_models.txt",
-            quote = FALSE, sep = "\t", row.names = FALSE)
-
 write_parquet(top_genes_impc_models_tidy,
-              "./data/output/phenodigm_scores_benchmarking_DR23_impc_models.parquet",
+              "./data/output/phenodigm_scores_benchmarking_impc_models.parquet",
               compression="zstd", compression_level=12)


### PR DESCRIPTION
# DR24 Post processing R script updates

General updates for DR24 analysis, DMP file generation, and Pheval file generation. 

## Plots
Violin plots are now generated for scores in both **associated** and **predicted** datasets. This should aid the inspection of score distribution and summary statistics for scores across data releases. This will be helpful to set score thresholds on the output files. 

## Output files
Output *txt* files have been removed and only parquet and fst files are written to reduce the size of the output. 

## PhenoDigm other table output
For the DMP's PhenoDigm other table, the output has grown considerably with the inclusion of HP-HP, HP-MP phenio mappings. The output is now distributed as both a single parquet file but also a dataset of multiple smaller files to comply with the 50MB limit for the DMP. 

